### PR TITLE
Ignore user wildignore settings

### DIFF
--- a/autoload/LanguageTool.vim
+++ b/autoload/LanguageTool.vim
@@ -17,7 +17,7 @@ function! LanguageTool#setup() "{{{1
     let s:summary_pp_flags = get(g:, 'languagetool_summary_flags', '')
     let s:preview_pp_flags = get(g:, 'languagetool_preview_flags', '')
 
-    if !filereadable(expand(s:languagetool_server))
+    if !filereadable(expand(s:languagetool_server, v:true))
         echomsg "LanguageTool cannot be found at: " . s:languagetool_server
         echomsg "You need to install LanguageTool and/or set up g:languagetool_server"
         echomsg "to indicate the location of the languagetool-server.jar file."


### PR DESCRIPTION
Vims `expand` function uses the `wildignore` settings. In my case I set this option to ignore `*.jar` files to ignore them, when expanding wildcards. 

However, this setting will expand the `s:languagetool_server` to an empty string, even if a valid `g:languagetool_server` path is set. 